### PR TITLE
Fix #23

### DIFF
--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -8,7 +8,7 @@ var del = require('del');
 var browserSync = require("browser-sync");
 
 gulp.task('images', function() {
-	gulp.src(config.images.src)
+	return gulp.src(config.images.src)
 		.pipe(plumber())
 		.pipe(gulp.dest(config.images.dst))
 		.pipe(browserSync.reload({stream: true}));
@@ -22,9 +22,8 @@ gulp.task('images-clean', function() {
 
 
 gulp.task("images-build", function() {
-	gulp.src(config.images.src)
+	return gulp.src(config.images.src)
 		.pipe(plumber())
 		.pipe(imagemin())
 		.pipe(gulp.dest(config.images.dst));
 })
-


### PR DESCRIPTION
Aparentemente, a função gulp.dest() roda assíncrona, e é finalizada antes
de terminar a sua execução, então o 'return', para forçar a completa execução dela
antes que o compile prossiga
